### PR TITLE
updated sparse checkout instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Instead, I recommend using the following procedure for performing a partial clon
 $ git clone --filter=blob:none --no-checkout https://github.com/mikeizbicki/metahtml
 $ cd metahtml
 $ git sparse-checkout init
-$ git sparse-checkout set '!/tests/.cache' '/*'
+$ git sparse-checkout set --no-cone '!/tests/.cache' '/*'
 $ git checkout master
 ```
 


### PR DESCRIPTION
In newer versions of Git, sparse-checkout has two modes: cone mode and pattern mode. In order for the pattern matching to work in the sparse-checkout instructions, the `--no-cone` argument must be passed. More info: [Stack Overflow](https://stackoverflow.com/questions/73803120/why-git-sparse-checkout-result-in-fatal-error), [Git documentation](https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-emsetem).